### PR TITLE
Fixed evaluation_committees_close

### DIFF
--- a/online/views.py
+++ b/online/views.py
@@ -144,7 +144,9 @@ def evaluation_committees_close(request):
 
     teams = Team.objects.all()
     teams_finalist = TeamFinalist.objects.all()
-    teams_finalist.delete()
+    if len(teams_finalist) > 0:
+        teams_finalist.delete()
+        
     for team in teams:
         total_score = 0
         scores = CategoryScore.objects.filter(is_committee_score=True, evaluation__team=team)

--- a/online/views.py
+++ b/online/views.py
@@ -146,7 +146,7 @@ def evaluation_committees_close(request):
     teams_finalist = TeamFinalist.objects.all()
     if len(teams_finalist) > 0:
         teams_finalist.delete()
-        
+
     for team in teams:
         total_score = 0
         scores = CategoryScore.objects.filter(is_committee_score=True, evaluation__team=team)


### PR DESCRIPTION
Ther was an error while trying to delete Team_Finalist at online>views.py>evaluation_committees_close when Team_Finalist was empty